### PR TITLE
docs: add AGENTS.md, ARCHITECTURE.md, CONTRIBUTING.md and first ADR [DX-1342]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## What this repo is
+
+`what-is-astro` is the companion demo for the Contentful blog guide
+[What is Astro](https://www.contentful.com/blog/what-is-astro/). It is a small
+Astro site for a fictional event ("Fake Astro Conf") that exists to illustrate
+the concepts in the article — content collections, references between
+collections, and hybrid rendering.
+
+It is **not** a product, a library, or a deployed service. There is no Contentful
+API integration in this repo: all content is local Markdown under
+`src/content/`. Treat it as sample code that a reader may clone while following
+the blog post.
+
+The last substantive change to the site itself was
+`e6936bc` (2023-09-06); everything after that is dependency, ownership, or
+tooling maintenance. Assume the repo is dormant and scope changes accordingly.
+
+## Commands
+
+Every command runs from the repo root. These are the only scripts defined in
+`package.json`:
+
+| Command           | What it does                                        |
+| :---------------- | :-------------------------------------------------- |
+| `npm install`     | Install dependencies                                |
+| `npm run dev`     | `astro dev --open` — dev server, opens a browser tab |
+| `npm run start`   | `astro dev` — dev server without opening a browser  |
+| `npm run build`   | `astro build` — production build into `dist/`       |
+| `npm run preview` | `astro preview` — serve the build locally           |
+| `npm run astro`   | Passthrough to the Astro CLI (e.g. `astro check`)   |
+
+There is **no test suite, no linter, and no formatter** configured in this repo,
+and no GitHub Actions workflows — `.github/` contains only `CODEOWNERS`. Do not
+report `npm test` or a lint step as having passed; neither exists. The closest
+thing to a verification step is `npm run astro -- check` plus `npm run build`.
+
+`.npmrc` sets `ignore-scripts=true`. Leave it in place — it is a deliberate
+supply-chain hardening choice (`3f2984d`).
+
+## Conventions to follow
+
+- ESM only. `package.json` sets `"type": "module"`; `astro.config.mjs` uses
+  `import`/`export`.
+- Component and layout files are `.astro` with the frontmatter fence (`---`) for
+  server-side script. Styles live in a `<style>` block in the same file — there
+  is no CSS framework and no separate stylesheet.
+- Global CSS and the custom properties `--accent` / `--accent-gradient` are
+  defined once in `src/layouts/Layout.astro` inside `<style is:global>`.
+- Content collections are declared in `src/content/config.js` using `zod` via
+  `astro:content`. If you add a frontmatter field to a Markdown entry, add it to
+  the matching schema in that file, or Astro will reject the entry.
+- `tsconfig.json` extends `astro/tsconfigs/base` and adds nothing. `.astro`
+  components in this repo are largely untyped beyond `Props` in `Layout.astro`.
+- Two-space indentation, double-quoted strings.
+
+## Rendering model — read before touching pages
+
+`astro.config.mjs` sets `output: "hybrid"` with the `@astrojs/node` adapter in
+`standalone` mode. Pages are prerendered at build time **unless** they opt out
+with `export const prerender = false`. Today only `src/pages/venue.astro` opts
+out, because it fetches live sunrise/sunset times on each request. See
+[docs/ADRs/2026-08-25-hybrid-output-with-node-adapter.md](docs/ADRs/2026-08-25-hybrid-output-with-node-adapter.md).
+
+Consequences an agent should keep in mind:
+
+- Removing the adapter or switching `output` to `"static"` will break
+  `venue.astro`.
+- `venue.astro` makes an unauthenticated outbound request to
+  `api.sunrise-sunset.org` with hard-coded latitude/longitude. It fails at
+  request time, not build time, if that host is unreachable.
+
+## Known rough edges
+
+These are real and present on `main`. Do not "fix" them incidentally in an
+unrelated change, but do not treat them as intentional either:
+
+- `src/components/TalkGrid.astro` passes `description={data.description}` to
+  `TalkCard`, but the `talk` collection schema in `src/content/config.js` has no
+  `description` field, so it is always `undefined` and the card body renders
+  empty.
+- `TalkGrid.astro` also passes `date`, which `TalkCard.astro` does not use.
+- The `speaker` reference between the `talk` and `speaker` collections — the
+  feature the blog post calls "the magic bit" — is declared and populated in
+  frontmatter but never resolved or rendered by any component.
+- `catalog-info.yaml` is still the unfilled Backstage template; its own header
+  comment says the fields need completing. `description`, `type`, `lifecycle`,
+  `system`, and the Slack channel are all `unknown`.
+
+## Boundaries
+
+- Ownership is `@contentful/team-devrel` (`.github/CODEOWNERS`). Route
+  non-trivial changes there.
+- Dependencies are managed by Renovate against the shared
+  `contentful/renovate-config` preset (`renovate.json`). Do not hand-bump
+  versions in `package.json` to chase an update; let Renovate open the PR.
+- Do not add secrets or `.env` files. `.gitignore` already excludes `.env` and
+  `.env.production`; leave those entries alone.
+- Because this repo backs a published article, keep the site's structure
+  recognisable to a reader following that article. A refactor that no longer
+  matches the prose is a regression even if the build passes.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,134 @@
+# Architecture
+
+`what-is-astro` is a single Astro application with no backend of its own and no
+external CMS integration. This document describes what is actually in the
+repository as of `66f5c61`.
+
+## Purpose and shape
+
+The site renders a fictional conference ("Fake Astro Conf") with a talk listing
+and a venue page. It accompanies the Contentful blog guide
+[What is Astro](https://www.contentful.com/blog/what-is-astro/), so its structure
+is chosen to demonstrate Astro features rather than to serve production traffic.
+
+Two dependencies, both direct:
+
+| Package         | Version    | Role                                       |
+| :-------------- | :--------- | :----------------------------------------- |
+| `astro`         | `^3.0.3`   | Framework, dev server, build, router       |
+| `@astrojs/node` | `^6.0.0`   | Server adapter for on-request rendering    |
+
+There are no devDependencies, no test framework, and no build tooling beyond
+Astro itself.
+
+## Directory layout
+
+```
+/
+├── astro.config.mjs        # output mode + Node adapter
+├── tsconfig.json           # extends astro/tsconfigs/base, nothing else
+├── renovate.json           # extends local>contentful/renovate-config
+├── .npmrc                  # ignore-scripts=true
+├── catalog-info.yaml        # Backstage descriptor (still template values)
+├── public/
+│   └── favicon.svg          # served as-is at /favicon.svg
+└── src/
+    ├── env.d.ts             # Astro ambient types
+    ├── content/
+    │   ├── config.js         # collection schemas (zod)
+    │   ├── talk/*.md         # 2 entries
+    │   └── speaker/*.md      # 2 entries
+    ├── layouts/
+    │   └── Layout.astro      # HTML shell + all global CSS
+    ├── components/
+    │   ├── TalkGrid.astro    # queries the talk collection
+    │   └── TalkCard.astro    # presentational card
+    └── pages/
+        ├── index.astro       # route /   (prerendered)
+        └── venue.astro       # route /venue (rendered per request)
+```
+
+Routing is file-based: every file in `src/pages/` becomes a route named after the
+file. There is no router configuration.
+
+## Rendering model
+
+`astro.config.mjs` is the whole of the runtime configuration:
+
+```js
+export default defineConfig({
+  output: "hybrid",
+  adapter: node({ mode: "standalone" })
+});
+```
+
+`hybrid` means **prerender by default, opt out per page**. A page becomes
+server-rendered by exporting `prerender = false`. Only `src/pages/venue.astro`
+does this, because it calls `api.sunrise-sunset.org` for sunrise and sunset times
+at request time using a fixed latitude/longitude embedded in the page.
+
+`npm run build` therefore produces two things in `dist/`: static HTML for `/`,
+and a standalone Node server entry point that handles `/venue`. `standalone` mode
+means the build emits a server that listens on its own rather than a middleware
+handler you mount in an existing Express or Fastify app.
+
+The rationale and history of this choice are recorded in
+[docs/ADRs/2026-08-25-hybrid-output-with-node-adapter.md](docs/ADRs/2026-08-25-hybrid-output-with-node-adapter.md).
+
+## Content model
+
+Content is local Markdown, validated by Astro's content collections. `src/content/config.js`
+defines two collections:
+
+- **`talk`** — `title: string`, `date: date`, `speaker: reference("speaker")`
+- **`speaker`** — `name: string`, `title: string`, `twitter?: string`
+
+The `reference("speaker")` field is the feature the blog post highlights: a talk
+names a speaker by that speaker's filename (`alvin`, `harshil`) and Astro
+type-checks the link at build time. Note that no component currently resolves
+that reference into rendered output — see the "Known rough edges" section of
+[AGENTS.md](AGENTS.md).
+
+Schema validation is enforced at build time. Adding a frontmatter key to a
+Markdown entry without adding it to the schema in `src/content/config.js` fails
+the build; passing a prop that no schema defines silently yields `undefined`,
+which is what currently happens to `description` in `TalkGrid.astro`.
+
+## Data flow
+
+```
+src/content/talk/*.md ──┐
+                        ├─> getCollection("talk") in TalkGrid.astro ─> TalkCard.astro ─> /
+src/content/config.js ──┘   (build time, prerendered)
+
+api.sunrise-sunset.org ────> fetch() in venue.astro ─────────────────────────────> /venue
+                             (request time, prerender = false)
+```
+
+Styling flows one way: `Layout.astro` declares global CSS and the `--accent` /
+`--accent-gradient` custom properties in a `<style is:global>` block; components
+consume those variables in their own scoped `<style>` blocks. There is no CSS
+framework, preprocessor, or shared stylesheet file.
+
+## What is deliberately absent
+
+Knowing what is *not* here matters as much as what is:
+
+- **No CI.** `.github/` contains only `CODEOWNERS`. Nothing builds, lints, or
+  tests this repo automatically. `catalog-info.yaml` is tagged `sast-disabled`.
+- **No tests or linting.** No test runner, no ESLint, no Prettier config.
+- **No deployment configuration.** No Dockerfile, no `netlify.toml`, no
+  `vercel.json`, no workflow that publishes anything. The Node adapter makes the
+  site *deployable*, but this repo does not describe where or how.
+- **No Contentful integration.** Despite the org, there is no Contentful SDK
+  dependency and no space or delivery token anywhere in the tree.
+- **No pinned Node version.** There is no `.nvmrc` and no `engines` field. Use a
+  Node version that satisfies Astro 3 and `@astrojs/node` 6.
+
+## Operational ownership
+
+`.github/CODEOWNERS` assigns the whole tree to `@contentful/team-devrel`, and
+`catalog-info.yaml` names the same group as owner at service tier 4. The
+Backstage descriptor is otherwise unfilled — `type`, `lifecycle`, `system`, and
+the CI alert channel are all `unknown` — so treat Backstage as an unreliable
+source of truth for this component until someone completes it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing
+
+Thanks for looking at this repo. Before you invest time, read the next section —
+it will tell you whether a change here is worth making.
+
+## What this repo is for
+
+This is the companion demo for the Contentful blog guide
+[What is Astro](https://www.contentful.com/blog/what-is-astro/). Its job is to
+match that article so a reader can clone it and follow along. It is not a
+product, a starter template we support, or a deployed site.
+
+The site has not changed substantively since 2023-09-06 (`e6936bc`); every commit
+since is dependency, ownership, or tooling upkeep. Two consequences:
+
+- **Changes that keep the code matching the article are welcome** — a broken
+  example, an outdated Astro API, a dependency that no longer installs.
+- **Changes that improve the demo beyond the article are probably not.** New
+  pages, a component library, a CSS framework, or a test suite would make the
+  repo diverge from the prose it exists to illustrate. Open an issue and talk to
+  `@contentful/team-devrel` before writing that code.
+
+If you found a mistake in the *article* rather than the code, this repo is the
+wrong place — that content is published separately.
+
+## Getting set up
+
+```sh
+git clone https://github.com/contentful/what-is-astro.git
+cd what-is-astro
+npm install
+npm run dev
+```
+
+`npm run dev` runs `astro dev --open` and opens a browser tab. Use
+`npm run start` if you would rather it not. No environment variables, API keys,
+or Contentful credentials are needed — all content is local Markdown in
+`src/content/`.
+
+There is no pinned Node version (`.nvmrc` and `engines` are both absent). Use a
+release that satisfies Astro 3 and `@astrojs/node` 6.
+
+`.npmrc` sets `ignore-scripts=true`, so `npm install` will not run dependency
+lifecycle scripts. That is intentional (`3f2984d`) — do not remove it to work
+around an install problem.
+
+## Verifying a change
+
+This repo has no test suite, no linter, and no CI. Nothing will catch a mistake
+for you, so check your work manually:
+
+```sh
+npm run astro -- check   # type and template diagnostics
+npm run build            # must succeed; content schemas validate here
+npm run preview          # serve the build and click through / and /venue
+```
+
+Check both routes, not just `/`. `/venue` is server-rendered per request and
+fetches an external API, so it can build cleanly and still fail when loaded. See
+[ARCHITECTURE.md](ARCHITECTURE.md) for why.
+
+If you touch `src/content/config.js` or any Markdown frontmatter, `npm run build`
+is the step that validates the collection schemas — do not skip it.
+
+## Conventions
+
+- ESM only; `package.json` sets `"type": "module"`.
+- Two-space indentation, double-quoted strings.
+- Styles go in a `<style>` block inside the `.astro` file that uses them. Global
+  CSS and the `--accent` custom properties belong in `src/layouts/Layout.astro`.
+- Add a new route by adding a file to `src/pages/`. Routing is file-based.
+- A new page is prerendered by default. Add `export const prerender = false` only
+  if it genuinely needs per-request data.
+- New frontmatter fields must be added to the matching schema in
+  `src/content/config.js`.
+
+`AGENTS.md` documents the same conventions in the form coding agents consume, plus
+a list of known rough edges on `main`. Read it before assuming something is a bug
+you introduced.
+
+## Dependencies
+
+Renovate manages updates against the shared `contentful/renovate-config` preset
+(`renovate.json`, wired up in `66f5c61`). Please do not hand-bump versions in
+`package.json` — let Renovate open the PR so the lockfile stays consistent. If a
+dependency needs an update Renovate is not proposing, say so in an issue.
+
+## Pull requests
+
+- Branch from `main` and open the PR against `main`.
+- Keep the change scoped. This repo is small enough that a mixed-purpose PR is
+  harder to review than two focused ones.
+- `.github/CODEOWNERS` assigns everything to `@contentful/team-devrel`, so they
+  are requested automatically. Give them time — this repo is low-traffic and not
+  on anyone's daily rotation.
+- No CI will run on your PR. State in the description what you ran locally and
+  what you saw, including which routes you loaded.
+- Commit messages on `main` use Conventional Commit prefixes where a prefix
+  applies (`chore:`, `fix:`), though history is not strict about it. Match the
+  prefix style; no release automation depends on it.
+
+## Reporting problems
+
+Open a GitHub issue on `contentful/what-is-astro`. Include the Astro and Node
+versions you used, the command you ran, and the output. If the problem is that
+the repo no longer matches the blog post, quote the part of the post that no
+longer holds — that is the most useful bug report this repo can get.
+
+Do not include Contentful credentials, tokens, or `.env` contents in an issue or
+PR. Nothing here needs them.

--- a/docs/ADRs/2026-08-25-hybrid-output-with-node-adapter.md
+++ b/docs/ADRs/2026-08-25-hybrid-output-with-node-adapter.md
@@ -1,0 +1,89 @@
+# Hybrid output with the standalone Node adapter
+
+- **Date:** 2026-08-25
+- **Status:** Accepted (in effect since 2023-05-25; adapter wiring completed 2023-09-06)
+
+> This record was written on 2026-08-25 from the commit history. It documents an
+> existing decision rather than a new one. The commits and configuration cited
+> below are verifiable; the reasoning attributed to them is reconstructed from
+> what the code does, not from any contemporaneous design note. Where the history
+> does not establish intent, this record says so instead of guessing.
+
+## Context
+
+`what-is-astro` is the companion demo for the Contentful blog guide
+[What is Astro](https://www.contentful.com/blog/what-is-astro/). The repository
+started from `npm create astro@latest -- --template basics` (`e7f61c6`,
+2023-05-18) with an empty `astro.config.mjs` — that is, fully static output.
+
+The demo then grew a page that cannot be static. `src/pages/venue.astro` calls
+`api.sunrise-sunset.org` for sunrise and sunset times at a fixed latitude and
+longitude, and presents them as current. Baked into a static build, those values
+would be frozen at whatever they were when the site was built. The talk listing
+on `/`, by contrast, is built entirely from local Markdown in `src/content/` and
+has no reason to be rendered per request.
+
+So the repo needed a per-page choice, not a whole-site one — and it needed that
+choice to be visible to a reader following the article, since demonstrating this
+capability is part of the article's subject matter.
+
+## Decision
+
+Configure Astro with `output: "hybrid"` and the `@astrojs/node` adapter in
+`standalone` mode. The whole of `astro.config.mjs` is:
+
+```js
+export default defineConfig({
+  output: "hybrid",
+  adapter: node({ mode: "standalone" })
+});
+```
+
+Under `hybrid`, pages are prerendered at build time unless a page opts out with
+`export const prerender = false`. Only `src/pages/venue.astro` opts out. The
+adapter supplies the server needed to render that one route on request;
+`standalone` means the build emits a server that listens on its own, rather than a
+middleware handler to be mounted inside an existing Node application.
+
+## Evidence
+
+Three commits, in order:
+
+| Commit    | Date       | What changed                                                                 |
+| :-------- | :--------- | :--------------------------------------------------------------------------- |
+| `ce80f47` | 2023-05-25 | Added `output: "hybrid"` behind `experimental.hybridOutput`, added `@astrojs/node@^5.1.4` to dependencies, and added `src/pages/venue.astro` with the sunrise/sunset fetch — all in one commit |
+| `44576f9` | 2023-06-15 | Removed the `experimental.hybridOutput` flag; commit message: "Hybrid rendering is no longer experimental" |
+| `e6936bc` | 2023-09-06 | Imported `@astrojs/node` in `astro.config.mjs` and set `adapter: node({ mode: "standalone" })`; commit message: "Added missing adapter" |
+
+`ce80f47` is the load-bearing one: it introduced hybrid output, the dependency,
+and the page that motivates hybrid output together. That grouping is why this
+record treats `venue.astro` as the driver of the decision rather than an
+incidental later addition.
+
+One detail worth recording because it is easy to misread: `@astrojs/node` was a
+declared dependency from `ce80f47` (2023-05-25) but was not referenced in
+`astro.config.mjs` until `e6936bc` (2023-09-06) — roughly three and a half
+months during which the package was installed but unused, spanning the Astro 3
+upgrade in `fb14ab8`. The `e6936bc` message calls the adapter "missing", so the
+adapter was evidently always the intent and the config wiring was an oversight.
+**The history does not establish why the gap went unnoticed for that long**, and
+this record does not speculate.
+
+## Consequences
+
+- A new page under `src/pages/` is static by default. Making it dynamic is a
+  one-line opt-out in that file, with no config change — which is the property
+  the blog post is demonstrating.
+- `npm run build` emits both static HTML and a Node server entry point in
+  `dist/`. Deploying this site therefore needs a Node runtime, not just static
+  file hosting. **This repository does not describe where or how it is deployed**
+  — there is no Dockerfile, no host configuration, and no publishing workflow.
+- `/venue` can fail at request time while the build is green, if
+  `api.sunrise-sunset.org` is unreachable. The page does not handle a failed
+  `fetch`. Verifying a change means loading `/venue`, not just building.
+- Switching to `output: "static"` or dropping the adapter breaks `venue.astro`.
+  Both are the same change in effect, and neither is safe on its own.
+- The adapter is a real dependency surface for a demo whose visible content is
+  otherwise entirely local Markdown. Renovate (`66f5c61`) keeps both `astro` and
+  `@astrojs/node` current; their major versions need to stay compatible with each
+  other.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -1,0 +1,11 @@
+# Architectural decision records
+
+Records of decisions this repository actually made, with the commits that
+evidence them. Newest first.
+
+| Date       | Record                                                                                     | Status   |
+| :--------- | :----------------------------------------------------------------------------------------- | :------- |
+| 2026-08-25 | [Hybrid output with the standalone Node adapter](2026-08-25-hybrid-output-with-node-adapter.md) | Accepted |
+
+Filename convention: `YYYY-MM-DD-kebab-case-title.md`. Records written after the
+fact should say so and cite the commits they were reconstructed from.


### PR DESCRIPTION
## Why

Part of the AI harness readiness rollout (DX-1296). This repo was audited on 2026-08-19 and satisfied **0 of 4** controls. This PR closes all four.

> **This PR comes from a fork** (`chasepoirier/what-is-astro`) because the author does not have write access to `contentful/what-is-astro`. A maintainer from @contentful/team-devrel should confirm ownership of this repo and of the content below before merging.

## Controls closed

| Control | File | Non-blank lines |
| :-- | :-- | --: |
| `agents-md-present` | `AGENTS.md` | 83 |
| `architecture-md-present` | `ARCHITECTURE.md` | 105 |
| `contributing-md-present` | `CONTRIBUTING.md` | 84 |
| `decision-records-present` | `docs/ADRs/2026-08-25-hybrid-output-with-node-adapter.md` | 72 |

Also adds `docs/ADRs/README.md` as the record index.

## What's in them

Written against what this repo actually is: the companion demo for the [What is Astro](https://www.contentful.com/blog/what-is-astro/) blog guide, not a product. Every command documented is one of the five scripts in `package.json` — nothing invented from Astro convention.

- **AGENTS.md** — purpose and scope, the real npm scripts, the hybrid rendering model and what breaks if you change it, and the conventions actually in use (ESM, scoped `<style>` blocks, collection schemas in `src/content/config.js`).
- **ARCHITECTURE.md** — directory layout, the two direct dependencies, the `talk`/`speaker` collection schemas and the reference between them, data flow, and ownership.
- **CONTRIBUTING.md** — setup (no credentials needed; all content is local Markdown), manual verification steps, PR expectations, and Renovate-owned dependency updates.

Both AGENTS.md and ARCHITECTURE.md are explicit that this repo has **no CI, no tests, and no linter** — `.github/` contains only `CODEOWNERS` — so an agent doesn't report a lint or test step as passing when none exists.

## The ADR — please read, it is a reconstruction

`docs/ADRs/2026-08-25-hybrid-output-with-node-adapter.md` documents the choice of `output: "hybrid"` with the `@astrojs/node` adapter in `standalone` mode.

**It was written on 2026-08-25 from commit history, not at the time of the decision, and says so in a callout at the top.** Its evidence:

- `ce80f47` (2023-05-25) — introduced `output: "hybrid"` behind `experimental.hybridOutput`, added `@astrojs/node@^5.1.4`, and added `src/pages/venue.astro` (the page that motivates hybrid output) in a single commit
- `44576f9` (2023-06-15) — dropped the experimental flag
- `e6936bc` (2023-09-06) — wired the adapter into `astro.config.mjs`; message reads "Added missing adapter"

Where history doesn't establish intent, the record says so rather than guessing — specifically, `@astrojs/node` was a declared dependency for about three and a half months before it was referenced in `astro.config.mjs`, and the ADR states plainly that it does not know why that gap went unnoticed.

If any of the reconstructed reasoning is wrong, please correct it in review — that's the part most worth a maintainer's eyes.

## Things surfaced along the way (not fixed here)

Documented in the "Known rough edges" section of AGENTS.md rather than changed, since this is a docs-only PR:

- `TalkGrid.astro` passes `description={data.description}` to `TalkCard`, but the `talk` schema has no `description` field — so every card body renders empty
- `TalkGrid.astro` also passes `date`, which `TalkCard.astro` ignores
- The `speaker` reference between collections — what `src/content/config.js` calls "the magic bit", and a feature of the blog post — is declared and populated but never resolved or rendered
- `catalog-info.yaml` is still the unfilled Backstage template; `description`, `type`, `lifecycle`, and `system` are all `unknown`

## Scope

Docs only — no source, config, or dependency changes. No installs, builds, or test suites were run. Refs DX-1342.